### PR TITLE
Bump `image` to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ exclude = [
 ]
 
 [dependencies]
-image = { version = "0.23", default-features = false, optional = true }
+image = { version = "0.24", default-features = false, optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 
 [build-dependencies]
-image = { version = "0.23", default-features = false, optional = true }
+image = { version = "0.24", default-features = false, optional = true }
 rayon = { version = "1.5.1", optional = true }
 resvg = { version = "0.20.0", optional = true }
 tiny-skia = { version = "0.6.2", optional = true }

--- a/src/raster_renderer/renderer.rs
+++ b/src/raster_renderer/renderer.rs
@@ -69,7 +69,7 @@ impl<'a, T: TileSet> RasterRenderer<'a, T> {
             let (width, height) = self.calculate_group_size(group);
             let mut sub_image =
                 imageops::crop(image, start_x, image.height() - height, width, height);
-            self.render_group(group, &mut sub_image);
+            self.render_group(group, &mut *sub_image);
 
             start_x += width + self.group_gap();
         }
@@ -86,7 +86,7 @@ impl<'a, T: TileSet> RasterRenderer<'a, T> {
 
             let mut sub_image =
                 imageops::crop(image, start_x, image.height() - height, width, height);
-            self.render_tile(tile, &mut sub_image);
+            self.render_tile(tile, &mut *sub_image);
 
             last_placement = tile.placement;
             start_x += width + self.tile_gap();


### PR DESCRIPTION
As of 0.24, `SubImage` stoppped implementing `GenericImage` ([docs](https://docs.rs/image/0.24.1/image/struct.SubImage.html)) -- instead, explicit conversion (e.g. by dereferencing) is expected.